### PR TITLE
new cli for switching mode between teamd legacy/unified design

### DIFF
--- a/tests/portchannel_test.py
+++ b/tests/portchannel_test.py
@@ -278,13 +278,176 @@ class TestPortChannel(object):
         assert result.exit_code != 0
         assert "PortChannel1001 has vlan Vlan4000 configured, remove vlan membership to proceed" in result.output
 
+    def test_portchannel_mode_multi_process_help(self):
+        """Test help message for multi-process mode command"""
+        runner = CliRunner()
+
+        # Check if the command structure uses a hyphen instead of underscore
+        # Try both 'multi-process' and 'multi_process' to diagnose the issue
+        try:
+            # Option 1: Using hyphen
+            result = runner.invoke(config.config.commands["portchannel"]
+                                   .commands["mode"].commands["multi-process"], ["--help"])
+        except KeyError:
+            try:
+                # Option 2: Using underscore
+                result = runner.invoke(config.config.commands["portchannel"]
+                                       .commands["mode"].commands["multi_process"], ["--help"])
+            except KeyError:
+                # Option 3: Direct child of portchannel
+                result = runner.invoke(config.config.commands["portchannel"]
+                                       .commands["multi-process"], ["--help"])
+
+        # Verify command executes and shows help
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert "Enable or disable multi-process mode" in result.output
+        assert "<enable|disable>" in result.output
+
+    def test_portchannel_mode_invalid_action(self):
+        """Test invalid action parameter"""
+        runner = CliRunner()
+        db = Db()
+        obj = {'db': db.cfgdb}
+
+        # Use the correct command structure based on what works in the help test
+        try:
+            # Option 1: Using hyphen
+            result = runner.invoke(config.config.commands["portchannel"]
+                                   .commands["mode"].commands["multi-process"], ["invalid"],
+                                   obj=obj)
+        except KeyError:
+            try:
+                # Option 2: Using underscore
+                result = runner.invoke(config.config.commands["portchannel"]
+                                       .commands["mode"].commands["multi_process"], ["invalid"],
+                                       obj=obj)
+            except KeyError:
+                # Option 3: Direct child of portchannel
+                result = runner.invoke(config.config.commands["portchannel"]
+                                       .commands["multi-process"], ["invalid"],
+                                       obj=obj)
+
+        # Verify expected error message
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Error: Invalid value for \"<enable|disable>\"" in result.output
+        assert "invalid choice: invalid. (choose from enable, disable)" in result.output
+
+    def test_portchannel_mode_missing_action(self):
+        """Test missing action parameter"""
+        runner = CliRunner()
+        db = Db()
+        obj = {'db': db.cfgdb}
+
+        # Use the correct command structure based on what works in the help test
+        try:
+            # Option 1: Using hyphen
+            result = runner.invoke(config.config.commands["portchannel"]
+                                   .commands["mode"].commands["multi-process"], [],
+                                   obj=obj)
+        except KeyError:
+            try:
+                # Option 2: Using underscore
+                result = runner.invoke(config.config.commands["portchannel"]
+                                       .commands["mode"].commands["multi_process"], [],
+                                       obj=obj)
+            except KeyError:
+                # Option 3: Direct child of portchannel
+                result = runner.invoke(config.config.commands["portchannel"]
+                                       .commands["multi-process"], [],
+                                       obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        # Verify expected error message
+        assert result.exit_code != 0
+        assert "Error: Missing argument \"<enable|disable>\"" in result.output
+
+    def test_portchannel_mode_enable_and_disable(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db': db.cfgdb}
+
+        # Enable multi-process mode
+        result = runner.invoke(config.config.commands["portchannel"]
+                               .commands["mode"].commands["multi-process"], ["enable"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert ("[WARNING] multi-process mode is configured. Please restart the teamd docker to take effect."
+                in result.output)
+
+        # Disable multi-process mode
+        result = runner.invoke(config.config.commands["portchannel"]
+                               .commands["mode"].commands["multi-process"], ["disable"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert ("[WARNING] multi-process mode is removed. Please restart the teamd docker to take effect."
+               in result.output)
+
+    def test_portchannel_mode_enable_when_already_enabled(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db': db.cfgdb}
+
+        # Enable multi-process mode
+        result = runner.invoke(config.config.commands["portchannel"]
+                               .commands["mode"].commands["multi-process"], ["enable"], obj=obj)
+        assert result.exit_code == 0
+
+        # Enable multi-process mode - already enabled
+        result = runner.invoke(config.config.commands["portchannel"]
+                               .commands["mode"].commands["multi-process"], ["enable"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert "Multi-process mode is already enabled" in result.output
+
+    def test_portchannel_mode_disable_when_already_disabled(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db': db.cfgdb}
+
+        # Disable multi-process mode - mode currently not enabled
+        result = runner.invoke(config.config.commands["portchannel"]
+                               .commands["mode"].commands["multi-process"], ["disable"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert "Multi-process mode is not currently enabled" in result.output
+
+    def test_portchannel_mode_enable_and_disable_with_invalid_db(self):
+        runner = CliRunner()
+
+        # Simulate broken db object
+        fake_db = "not-a-db-object"
+        obj = {'db': fake_db}
+
+        result = runner.invoke(config.config.commands["portchannel"]
+                               .commands["mode"].commands["multi-process"], ['enable'], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Failed to enable multi-process mode" in result.output
+
+        result = runner.invoke(config.config.commands["portchannel"]
+                               .commands["mode"].commands["multi-process"], ['disable'], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Failed to disable multi-process mode" in result.output
+
     def test_get_invalid_portchannel_retry_count(self):
         runner = CliRunner()
         db = Db()
-        obj = {'db':db.cfgdb}
+        obj = {'db': db.cfgdb}
 
         # get the retry count of a portchannel with an invalid portchannel name
-        result = runner.invoke(config.config.commands["portchannel"].commands["retry-count"].commands["get"], ["Ethernet48"], obj=obj)
+        result = runner.invoke(config.config.commands["portchannel"]
+                               .commands["retry-count"].commands["get"], ["Ethernet48"], obj=obj)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code != 0


### PR DESCRIPTION
**CLI:**

config portchannel mode multi-process <enable/disable>

**Test Coverage log:**

admin@sonic:/Vasanth/coverage/sonic-utilities$ diff-cover coverage.xml --compare-branch HEAD~1

...................................................
Diff Coverage
Diff: HEAD~1...HEAD, staged and unstaged changes
...................................................
config/main.py (96.0%): Missing lines 2621
..................................................
Total: 25 lines
Missing: 1 line
Coverage: 96%
.................................................

admin@sonic:~/Vasanth/coverage/sonic-utilities$

**pre-commit log:**

admin@sonic:/Vasanth/coverage/sonic-utilities$ pre-commit run flake8 --all-files
flake8...................................................................Passed
admin@sonic:/Vasanth/coverage/sonic-utilities$

**Cli-plugin-tests logs:**
[cli_plugin_test_logs.txt](https://github.com/user-attachments/files/21316347/cli_plugin_test_logs.txt)


**cli-unit-tests-logs:**
[cli_unit_test_logs.txt](https://github.com/user-attachments/files/21316365/cli_unit_test_logs.txt)
