### PR TITLE
Implementation of CLI commands show portchannel info and sonic-clear portchannel statistics - teamd serviceability [DONT MERGE]

### DIFF
--- a/clear/main.py
+++ b/clear/main.py
@@ -13,6 +13,8 @@ from show.plugins.pbh import read_pbh_counters
 from config.plugins.pbh import serialize_pbh_counters
 from . import plugins
 from . import stp
+from . import portchannel
+
 # This is from the aliases example:
 # https://github.com/pallets/click/blob/57c6f09611fc47ca80db0bd010f05998b3c0aa95/examples/aliases/aliases.py
 class Config(object):
@@ -148,6 +150,10 @@ def ipv6():
 # 'STP'
 #
 cli.add_command(stp.spanning_tree)
+
+# 'portchannel'
+#
+cli.add_command(portchannel.portchannel)
 
 #
 # Inserting BGP functionality into cli's clear parse-chain.

--- a/clear/portchannel.py
+++ b/clear/portchannel.py
@@ -1,0 +1,70 @@
+import click
+import utilities_common.cli as clicommon
+from natsort import natsorted
+from swsscommon.swsscommon import SonicV2Connector
+
+
+def check_portchannel_name_member_port_exists(portchannel_name, port_name):
+    db = SonicV2Connector(host='127.0.0.1')
+    db.connect(db.STATE_DB)
+    KEY = 'LAG_TABLE|' + portchannel_name
+    if not db.exists(db.STATE_DB, KEY):
+        return False
+    if port_name:
+        MKEY = 'LAG_MEMBER_TABLE|' + portchannel_name + '|' + port_name
+        if not db.exists(db.STATE_DB, MKEY):
+            return False
+    return True
+
+
+@click.group()
+def portchannel():
+    """Clear portchannel lacp stats counters"""
+    pass
+
+
+@click.command('statistics')
+@click.argument('portchannel_name', metavar='<portchannel_name>', required=False)
+@click.argument('port_name', metavar='<port_name>', required=False)
+def statistics(portchannel_name, port_name):
+    """clearing statistics"""
+    if portchannel_name and port_name is None:
+        valid = check_portchannel_name_member_port_exists(portchannel_name, None)
+        if not valid:
+            click.echo("No such portchannel interface : {}". format(portchannel_name))
+            return
+        command = 'sudo teamdctl ' + portchannel_name + ' clear statistics'
+        try:
+            clicommon.run_command(command, shell=True)
+            click.echo("Cleared stats counter for LAG : {}". format(portchannel_name))
+        except Exception as e:
+            click.echo("Warning: Could not clear stats for {} {}". format(portchannel_name, str(e)))
+    elif portchannel_name and port_name:
+        valid = check_portchannel_name_member_port_exists(portchannel_name, port_name)
+        if not valid:
+            click.echo(f"No such portchannel or portchannel member interface : {portchannel_name} {port_name}")
+            return
+        command = 'sudo teamdctl ' + portchannel_name + ' clear statistics port ' + port_name
+        try:
+            clicommon.run_command(command, shell=True)
+            click.echo("Cleared stats counter for LAG : {} LAG_MEMBER : {}". format(portchannel_name, port_name))
+        except Exception as e:
+            click.echo("Warning: Could not clear stats for {} {} {}". format(portchannel_name, port_name, str(e)))
+    elif portchannel_name is None and port_name is None:
+        db = SonicV2Connector(host='127.0.0.1')
+        db.connect(db.STATE_DB)
+        lag_keys = db.keys(db.STATE_DB, 'LAG_TABLE|*')
+        cleared = True
+        for lag_key in natsorted(lag_keys):
+            lag_name = lag_key.split('|')[-1]
+            command = 'sudo teamdctl ' + lag_name + ' clear statistics'
+            try:
+                clicommon.run_command(command, shell=True)
+            except Exception as e:
+                cleared = False
+                click.echo("Warning: Could not clear stats for {} {}". format(lag_name, str(e)))
+        if cleared:
+            click.echo("Cleared stats counter for all LAGs")
+
+
+portchannel.add_command(statistics)

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2274,6 +2274,8 @@ main() {
     save_cmd "show spanning-tree bpdu_guard" "stp.bg"
     save_cmd "show spanning-tree root_guard" "stp.rg"
 
+    save_cmd "show interfaces portchannel info" "portchannel.log"
+
     save_cmd "ps aux" "ps.aux" &
     save_cmd "top -b -n 1" "top" &
     save_cmd "free" "free" &

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -1105,7 +1105,16 @@
         "runner.aggregator.selected": "false",
         "runner.aggregator.id": "0",
         "link.up": "false",
-        "ifinfo.ifindex": "98"
+        "ifinfo.ifindex": "98",
+        "runner.statistics.lacpdu_illegal_pkts": "0",
+        "runner.statistics.lacpdu_rx_stats": "0",
+        "runner.actor_lacpdu_info.key": "11",
+        "runner.statistics.lacpdu_tx_stats": "1103",
+        "runner.actor_lacpdu_info.state": "69",
+        "runner.partner_lacpdu_info.key": "0",
+        "runner.partner_lacpdu_info.state": "2",
+        "runner.statistics.last_lacpdu_tx_time": "2025-06-26T07:54:23.926776098Z",
+        "runner.statistics.last_lacpdu_rx_time": "N/A"
     },
     "LAG_MEMBER_TABLE|PortChannel0002|Ethernet116": {
         "runner.actor_lacpdu_info.state": "61",
@@ -1121,7 +1130,16 @@
         "runner.aggregator.selected": "true",
         "runner.aggregator.id": "97",
         "link.up": "true",
-        "ifinfo.ifindex": "97"
+        "ifinfo.ifindex": "97",
+        "runner.statistics.lacpdu_illegal_pkts": "0",
+        "runner.statistics.lacpdu_rx_stats": "1003",
+        "runner.actor_lacpdu_info.key": "12",
+        "runner.statistics.lacpdu_tx_stats": "1103",
+        "runner.actor_lacpdu_info.state": "61",
+        "runner.partner_lacpdu_info.key": "13",
+        "runner.partner_lacpdu_info.state": "61",
+        "runner.statistics.last_lacpdu_tx_time": "2025-06-26T07:54:23.926776098Z",
+        "runner.statistics.last_lacpdu_rx_time": "2025-06-26T07:54:23.926776098Z"
     },
     "LAG_MEMBER_TABLE|PortChannel0003|Ethernet120": {
         "runner.actor_lacpdu_info.state": "61",
@@ -1137,7 +1155,16 @@
         "runner.aggregator.selected": "true",
         "runner.aggregator.id": "100",
         "link.up": "true",
-        "ifinfo.ifindex": "100"
+        "ifinfo.ifindex": "100",
+        "runner.statistics.lacpdu_illegal_pkts": "0",
+        "runner.statistics.lacpdu_rx_stats": "1003",
+        "runner.actor_lacpdu_info.key": "13",
+        "runner.statistics.lacpdu_tx_stats": "1103",
+        "runner.actor_lacpdu_info.state": "61",
+        "runner.partner_lacpdu_info.key": "12",
+        "runner.partner_lacpdu_info.state": "61",
+        "runner.statistics.last_lacpdu_tx_time": "2025-06-26T07:54:23.926776098Z",
+        "runner.statistics.last_lacpdu_rx_time": "2025-06-26T07:54:23.926776098Z"
     },
     "LAG_TABLE|PortChannel0001": {
         "runner.fallback": "false",
@@ -1147,7 +1174,12 @@
         "state": "ok",
         "runner.fast_rate": "false",
         "setup.kernel_team_mode_name": "loadbalance",
-        "runner.active": "true"
+        "runner.active": "true",
+        "runner.retry_count": "3",
+        "runner.min_ports": "1",
+        "runner.enable_retry_count_feature": "true",
+        "mtu": "9100",
+        "runner.sys_prio": "65535"
     },
     "LAG_TABLE|PortChannel0002": {
         "runner.fallback": "false",
@@ -1157,7 +1189,12 @@
         "state": "ok",
         "runner.fast_rate": "false",
         "setup.kernel_team_mode_name": "loadbalance",
-        "runner.active": "true"
+        "runner.active": "true",
+        "runner.retry_count": "3",
+        "runner.min_ports": "1",
+        "runner.enable_retry_count_feature": "true",
+        "mtu": "9100",
+        "runner.sys_prio": "65535"
     },
     "LAG_TABLE|PortChannel0003": {
         "runner.fallback": "false",
@@ -1167,7 +1204,12 @@
         "state": "ok",
         "runner.fast_rate": "false",
         "setup.kernel_team_mode_name": "loadbalance",
-        "runner.active": "true"
+        "runner.active": "true",
+        "runner.retry_count": "3",
+        "runner.min_ports": "1",
+        "runner.enable_retry_count_feature": "true",
+        "mtu": "9100",
+        "runner.sys_prio": "65535"
     },
     "LAG_TABLE|PortChannel0004": {
         "runner.fallback": "false",
@@ -1177,7 +1219,12 @@
         "state": "ok",
         "runner.fast_rate": "false",
         "setup.kernel_team_mode_name": "loadbalance",
-        "runner.active": "true"
+        "runner.active": "true",
+        "runner.retry_count": "3",
+        "runner.min_ports": "1",
+        "runner.enable_retry_count_feature": "true",
+        "mtu": "9100",
+        "runner.sys_prio": "65535"
     },
     "FAN_INFO|fan1": {
         "drawer_name": "drawer1",


### PR DESCRIPTION
**Teamd Serviceability** -

**CLI commands:**

show interfaces portchannel info <portchannel_name>

sonic-clear portchannel statistics <portchannel_name> <port_name>

