### PR TITLE
Addressed community review comment - Moved dhcpv4 flag from FEATURE table to DEVICE_METADATA table - DHCPv4

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -1266,16 +1266,21 @@ class DBMigrator():
         self.set_version('version_202305_01')
         return 'version_202305_01'
 
+    def check_has_sonic_dhcpv4_relay_flag(self):
+        device_metadata_table = self.configDB.get_table("DEVICE_METADATA")
+        dhcp_relay_feature = device_metadata_table.get("localhost", {})
+        if dhcp_relay_feature.get("has_sonic_dhcpv4_relay") == "True":
+            return True
+        return False
+
     def version_202305_01(self):
         """
         Version 202305_01.
         This is current last erversion for 202305 branch
         """
         log.log_info('Handling version_202305_01')
-        feature_table = self.configDB.get_table("FEATURE")
-        dhcp_relay_feature = feature_table.get("dhcp_relay", {})
-        if dhcp_relay_feature.get("has_sonic_dhcpv4_relay") == "True":
-            log.log_info("Triggering migrate_dhcp_servers_to_dhcpv4_relay() due to FEATURE|dhcp_relay")
+        if self.check_has_sonic_dhcpv4_relay_flag():
+            log.log_info("Triggering migrate_dhcp_servers_to_dhcpv4_relay()")
             self.migrate_dhcp_servers_to_dhcpv4_relay()
 
         self.set_version('version_202311_01')
@@ -1291,10 +1296,8 @@ class DBMigrator():
         self.migrate_dns_nameserver()
 
         self.migrate_sflow_table()
-        feature_table = self.configDB.get_table("FEATURE")
-        dhcp_relay_feature = feature_table.get("dhcp_relay", {})
-        if dhcp_relay_feature.get("has_sonic_dhcpv4_relay") == "True":
-            log.log_info("Triggering migrate_dhcp_servers_to_dhcpv4_relay() due to FEATURE|dhcp_relay")
+        if self.check_has_sonic_dhcpv4_relay_flag():
+            log.log_info("Triggering migrate_dhcp_servers_to_dhcpv4_relay()")
             self.migrate_dhcp_servers_to_dhcpv4_relay()
 
         self.set_version('version_202311_02')
@@ -1307,10 +1310,8 @@ class DBMigrator():
         log.log_info('Handling version_202311_02')
         # Update GNMI table
         self.migrate_gnmi()
-        feature_table = self.configDB.get_table("FEATURE")
-        dhcp_relay_feature = feature_table.get("dhcp_relay", {})
-        if dhcp_relay_feature.get("has_sonic_dhcpv4_relay") == "True":
-            log.log_info("Triggering migrate_dhcp_servers_to_dhcpv4_relay() due to FEATURE|dhcp_relay")
+        if self.check_has_sonic_dhcpv4_relay_flag():
+            log.log_info("Triggering migrate_dhcp_servers_to_dhcpv4_relay()")
             self.migrate_dhcp_servers_to_dhcpv4_relay()
 
         self.set_version('version_202311_03')
@@ -1322,10 +1323,8 @@ class DBMigrator():
         This is current last erversion for 202311 branch
         """
         log.log_info('Handling version_202311_03')
-        feature_table = self.configDB.get_table("FEATURE")
-        dhcp_relay_feature = feature_table.get("dhcp_relay", {})
-        if dhcp_relay_feature.get("has_sonic_dhcpv4_relay") == "True":
-            log.log_info("Triggering migrate_dhcp_servers_to_dhcpv4_relay() due to FEATURE|dhcp_relay")
+        if self.check_has_sonic_dhcpv4_relay_flag():
+            log.log_info("Triggering migrate_dhcp_servers_to_dhcpv4_relay()")
             self.migrate_dhcp_servers_to_dhcpv4_relay()
 
         self.set_version('version_202405_01')
@@ -1336,10 +1335,8 @@ class DBMigrator():
         Version 202405_01.
         """
         log.log_info('Handling version_202405_01')
-        feature_table = self.configDB.get_table("FEATURE")
-        dhcp_relay_feature = feature_table.get("dhcp_relay", {})
-        if dhcp_relay_feature.get("has_sonic_dhcpv4_relay") == "True":
-            log.log_info("Triggering migrate_dhcp_servers_to_dhcpv4_relay() due to FEATURE|dhcp_relay")
+        if self.check_has_sonic_dhcpv4_relay_flag():
+            log.log_info("Triggering migrate_dhcp_servers_to_dhcpv4_relay()")
             self.migrate_dhcp_servers_to_dhcpv4_relay()
 
         self.set_version('version_202405_02')
@@ -1350,10 +1347,8 @@ class DBMigrator():
         Version 202405_02.
         """
         log.log_info('Handling version_202405_02')
-        feature_table = self.configDB.get_table("FEATURE")
-        dhcp_relay_feature = feature_table.get("dhcp_relay", {})
-        if dhcp_relay_feature.get("has_sonic_dhcpv4_relay") == "True":
-            log.log_info("Triggering migrate_dhcp_servers_to_dhcpv4_relay() due to FEATURE|dhcp_relay")
+        if self.check_has_sonic_dhcpv4_relay_flag():
+            log.log_info("Triggering migrate_dhcp_servers_to_dhcpv4_relay()")
             self.migrate_dhcp_servers_to_dhcpv4_relay()
 
         self.migrate_ipinip_tunnel()
@@ -1365,6 +1360,10 @@ class DBMigrator():
         Version 202411_01.
         """
         log.log_info('Handling version_202411_01')
+        if self.check_has_sonic_dhcpv4_relay_flag():
+            log.log_info("Triggering migrate_dhcp_servers_to_dhcpv4_relay()")
+            self.migrate_dhcp_servers_to_dhcpv4_relay()
+
         self.set_version('version_202411_02')
         return 'version_202411_02'
 
@@ -1373,6 +1372,10 @@ class DBMigrator():
         Version 202411_02.
         """
         log.log_info('Handling version_202411_02')
+        if self.check_has_sonic_dhcpv4_relay_flag():
+            log.log_info("Triggering migrate_dhcp_servers_to_dhcpv4_relay()")
+            self.migrate_dhcp_servers_to_dhcpv4_relay()
+
         self.set_version('version_202505_01')
         return 'version_202505_01'
 
@@ -1382,6 +1385,10 @@ class DBMigrator():
         master branch until 202505 branch is created.
         """
         log.log_info('Handling version_202505_01')
+        if self.check_has_sonic_dhcpv4_relay_flag():
+            log.log_info("Triggering migrate_dhcp_servers_to_dhcpv4_relay()")
+            self.migrate_dhcp_servers_to_dhcpv4_relay()
+
         self.migrate_flex_counter_delay_status_removal()
         return None
 

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -362,6 +362,47 @@ class TestLacpKeyMigrator(object):
         assert dbmgtr.configDB.get_table('PORTCHANNEL') == expected_db.cfgdb.get_table('PORTCHANNEL')
         assert dbmgtr.configDB.get_table('VERSIONS') == expected_db.cfgdb.get_table('VERSIONS')
 
+
+class TestDhcpRelayKeyMigrator(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        dbconnector.dedicated_dbs['CONFIG_DB'] = None
+
+    def test_dhcp_relay_key_migrator(self):
+        import db_migrator
+        dbmgtr = db_migrator.DBMigrator(None)
+        print("CONFIG_DB keys:", dbmgtr.configDB.get_table('VLAN'))
+        print("DEVICE_METADATA:", dbmgtr.configDB.get_entry('DEVICE_METADATA', 'localhost'))
+        entry = dbmgtr.configDB.get_entry('DEVICE_METADATA', 'localhost') or {}
+        entry['has_sonic_dhcpv4_relay'] = 'True'
+        dbmgtr.configDB.set_entry('DEVICE_METADATA', 'localhost', entry)
+        dbmgtr.configDB.set_entry('VLAN', 'Vlan20', {
+                    'dhcp_servers': ['192.160.20.100'],
+                    'vlanid': '20'
+        })
+        dbmgtr.configDB.set_entry('VLAN', 'Vlan21', {
+                    'dhcp_servers': ['192.160.20.100'],
+                    'vlanid': '21'
+                    })
+        dbmgtr.configDB.set_entry('VLAN', 'Vlan80', {
+                    'dhcp_servers': ['19.16.20.10'],
+                    'vlanid': '80'
+                    })
+        dbmgtr.configDB.set_entry('VERSIONS', 'DATABASE', {
+                    'VERSION': 'version_202305_01'
+                    })
+        dbmgtr.configDB.set_entry('VLAN', 'Vlan90', {'vlanid': '90'})
+        dbmgtr.migrate()
+        dhcpv4_table = dbmgtr.configDB.get_table('DHCPV4_RELAY')
+        assert dbmgtr.configDB.get_entry('DEVICE_METADATA', 'localhost')['has_sonic_dhcpv4_relay'] == 'True'
+        assert dhcpv4_table.get('Vlan20')['dhcpv4_servers'] == ['192.160.20.100']
+        assert dhcpv4_table.get('Vlan80')['dhcpv4_servers'] == ['19.16.20.10']
+
 class TestDnsNameserverMigrator(object):
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
**Addressed community review comment:**

Moved "has_sonic_dhcpv4_relay" flag from FEATURE["dhcp_relay"] to DEVICE_METADATA["localhost"] table

https://github.com/sonic-net/sonic-dhcp-relay/pull/67

**spytest logs:**

[26700_dhcpv4_new_design_logs.zip](https://github.com/user-attachments/files/22494082/26700_dhcpv4_new_design_logs.zip)

[ISC_26700_logs.zip](https://github.com/user-attachments/files/22494087/ISC_26700_logs.zip)

[db_migration_reboot_logs.odt](https://github.com/user-attachments/files/22494444/db_migration_reboot_logs.odt)

**DB_migrator Coverage:**

<img width="941" height="238" alt="image" src="https://github.com/user-attachments/assets/f5f5e624-ae75-4162-8597-910cabccc2f4" />



